### PR TITLE
Make Instagram feed cacheable

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,7 +13,6 @@ call_user_func(
             ],
             // non-cacheable actions
             [
-                'Instagram' => 'showFeed'
             ]
         );
 


### PR DESCRIPTION
As far as I can see there is no reason to disable caching for showFeed as the generated content is static as long as the Instagram profile is not being updated.
There is probably no use case where the content updates more often than the minimum cache duration I could configure for the page which contains the feed in TYPO3.